### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -78,7 +78,7 @@ $(function(){
       $('.messages').append(html);
       $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
       $("#new_message")[0].reset();
-      $(".form__submit").prop("disabled", false);
+      $(".form__submit-btn").prop("disabled", false);
     })
     .fail(function(){
       alert("メッセージ送信に失敗しました");
@@ -102,7 +102,7 @@ $(function(){
         $('.messages').append(insertHTML);
         $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
         $("#new_message")[0].reset();
-        $(".form__submit").prop("disabled", false);
+        $(".form__submit-btn").prop("disabled", false);
       }
     })
     .fail(function() {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,8 @@
 $(function(){
-  function  buildHTML(message){
-    if (message.image) {
+  var buildHTML = function(message){
+    if (message.content && message.image) {
       var html = 
-        `<div class="message" >
+        `<div class="message" data-message-id = ${message.id}>
           <div class="message_log-message">
             <div class="message__log-message__upper-info">
               <div class="message__log-message__upper-info__talker">
@@ -21,9 +21,9 @@ $(function(){
           <img src=${message.image} >
         </div>`
       return html
-    } else {
+    } else if (message.content) {
       var html =
-        `<div class="message" >
+        `<div class="message" data-message-id = ${message.id}>
           <div class="message_log-message">
             <div class="message__log-message__upper-info">
               <div class="message__log-message__upper-info__talker">
@@ -40,8 +40,25 @@ $(function(){
             </p>
           </div>
         </div>`
-      return html
+    } else if (message.image){
+      var html = 
+        `<div class="message" data-message-id = ${message.id}>
+          <div class="message_log-message">
+            <div class="message__log-message__upper-info">
+              <div class="message__log-message__upper-info__talker">
+                ${message.user_name}
+              </div>
+              <div class="message__log-message__upper-info__date">
+                ${message.created_at}
+              </div>
+            </div>
+          </div>
+          <div class="message__lower-message">
+            <img src=${message.image} >
+          </div>
+        </div>`
     };
+    return html;
   }
 
   $('#new_message').on('submit', function(e){
@@ -60,11 +77,39 @@ $(function(){
       var html = buildHTML(data);
       $('.messages').append(html);
       $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
-      $('form')[0].reset();
-      $('.form__submit-btn').prop('disabled', false);
+      $("#new_message")[0].reset();
+      $(".form__submit").prop("disabled", false);
     })
     .fail(function(){
       alert("メッセージ送信に失敗しました");
     });
   });
+
+  var reloadMessages = function() {
+    last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+        $("#new_message")[0].reset();
+        $(".form__submit").prop("disabled", false);
+      }
+    })
+    .fail(function() {
+      alert("メッセージの更新に失敗しました");
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.to_s
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__log-message
     .message__log-message__upper-info
       .message__log-message__upper-info__talker

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.to_s
 json.content @message.content
 json.image @message.image.url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# WHAT
Chatspaceに自動更新機能を実装した。
- 2画面開き、メッセージ及び画像が自動更新されることを確認。
- 自動更新されたページは、更新ごとにメッセージ画面が自動で最下部にスクロールする。
- 7秒単位で更新される。

# WHY
- 同じグループ内で会話をするとき、送信したメッセージが送信先のユーザーページに反映されないと最新の
   メッセージを確認し合えない。
- 自動更新でメッセージを確認できるようになれば、いちいちリロードする必要がなくなる。